### PR TITLE
refactor(render.js): prevent internal updates to draw sources

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -41,16 +41,13 @@ module.exports = function render() {
   }
 
   if (coldChanged) {
-    store.ctx.map.getSource(Constants.sources.COLD).setData({
-      type: Constants.geojsonTypes.FEATURE_COLLECTION,
-      features: store.sources.cold
-    });
+    // Call a monkey-patched top-level API method, setSourceData, instead of the
+    // native MapboxGL getSource().setData() pattern. 
+    // This supports usage with react-map-gl.
+    store.ctx.map.setSourceData(Constants.sources.COLD, store.sources.cold)
   }
 
-  store.ctx.map.getSource(Constants.sources.HOT).setData({
-    type: Constants.geojsonTypes.FEATURE_COLLECTION,
-    features: store.sources.hot
-  });
+  store.ctx.map.setSourceData(Constants.sources.HOT, store.sources.hot)
 
   if (store._emitSelectionChange) {
     store.ctx.map.fire(Constants.events.SELECTION_CHANGE, {

--- a/src/render.js
+++ b/src/render.js
@@ -44,10 +44,10 @@ module.exports = function render() {
     // Call a monkey-patched top-level API method, setSourceData, instead of the
     // native MapboxGL getSource().setData() pattern. 
     // This supports usage with react-map-gl.
-    store.ctx.map.setSourceData(Constants.sources.COLD, store.sources.cold)
+    store.ctx.map.setSourceData(Constants.sources.COLD, store.sources.cold);
   }
 
-  store.ctx.map.setSourceData(Constants.sources.HOT, store.sources.hot)
+  store.ctx.map.setSourceData(Constants.sources.HOT, store.sources.hot);
 
   if (store._emitSelectionChange) {
     store.ctx.map.fire(Constants.events.SELECTION_CHANGE, {


### PR DESCRIPTION
This PR refactors map source updates from within `mapbox-gl-draw` such that they don't follow the `getSource().setData()` pattern but rather call a single, top-level method called `setSourceData` which is designed to be monkey-patched on the map instance at runtime.

The purpose of this is to reroute what would otherwise be internal state updates to React/Redux state so `react-map-gl` can remain stateless while using `mapbox-gl-draw`.

To be clear this is pretty hacky. We should replace this whole setup when `react-map-gl` introduces support for a drawing overlay.

Note that this PR breaks a bunch of tests that expect the map's store state to match certain conditions. Because usage of this fork is temporary and the forked changes are minimal we're not going to worry about the tests :).